### PR TITLE
use encoders for toStrings

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -20,22 +20,27 @@ ThisBuild / versionScheme := Some("early-semver")
 ThisBuild / organization := "org.scalawag.bateman"
 
 val Versions = new Object {
-  val cats = "2.8.0"
-  val circe = "0.14.3"
+  val cats = "2.9.0"
+  val circe = "0.14.1"
   val enumeratum = "1.7.0"
   val fastparse = "2.3.3"
-  val scalatest = "3.2.14"
+  val scalatest = "3.2.15"
   val shapeless = "2.3.10"
   val scalacheck = "1.17.0"
+  val scalaJavaTime = "2.5.0"
+  val secureRandom = "1.0.0"
+  val paradise = "2.1.1"
+  val collectionCompat = "2.9.0"
+  val kindProjector = "0.13.2"
 }
 
-val jvmScalaVersions = Seq("2.12.17", "2.13.9")
+val jvmScalaVersions = Seq("2.12.17", "2.13.10")
 val jsScalaVersions = jvmScalaVersions
 
 val commonSettings = Seq(
   organization := "org.scalawag.bateman",
 //  scalacOptions += "-Xlog-implicits",
-  addCompilerPlugin("org.typelevel" % "kind-projector" % "0.13.2" cross CrossVersion.full),
+  addCompilerPlugin("org.typelevel" % "kind-projector" % Versions.kindProjector cross CrossVersion.full),
   scalacOptions ++= Seq(
     "-language:higherKinds",
     "-language:implicitConversions",
@@ -89,12 +94,12 @@ val json = projectMatrix
     name := s"$projectBaseName-json",
     libraryDependencies ++= Seq(
       "org.typelevel" %%% "cats-core" % Versions.cats,
-      "org.scala-lang.modules" %%% "scala-collection-compat" % "2.7.0",
-      "io.github.cquiroz" %%% "scala-java-time" % "2.2.2",
+      "org.scala-lang.modules" %%% "scala-collection-compat" % Versions.collectionCompat,
+      "io.github.cquiroz" %%% "scala-java-time" % Versions.scalaJavaTime,
       "org.typelevel" %% "cats-core" % Versions.cats,
     ),
     libraryDependencies ++= Seq(
-      "io.github.cquiroz" %%% "scala-java-time" % "2.2.2"
+      "io.github.cquiroz" %%% "scala-java-time" % Versions.scalaJavaTime
     ).map(_ % Test)
   )
   .jvmPlatform(scalaVersions = jvmScalaVersions)
@@ -130,7 +135,7 @@ val jsonGeneric = projectMatrix
     libraryDependencies ++= {
       CrossVersion.partialVersion(scalaVersion.value) match {
         case Some((2, n)) if n <= 12 =>
-          List(compilerPlugin("org.scalamacros" % "paradise" % "2.1.1" cross CrossVersion.full))
+          List(compilerPlugin("org.scalamacros" % "paradise" % Versions.paradise cross CrossVersion.full))
         case _ =>
           Nil
       }
@@ -146,12 +151,12 @@ val jsonLiteral = projectMatrix
     name := s"$projectBaseName-json-literal",
     libraryDependencies ++= Seq(
       "org.scala-lang" % "scala-reflect" % scalaVersion.value,
-      "io.github.cquiroz" %%% "scala-java-time" % "2.2.2" % Test,
+      "io.github.cquiroz" %%% "scala-java-time" % Versions.scalaJavaTime % Test,
     ),
     libraryDependencies ++= {
       CrossVersion.partialVersion(scalaVersion.value) match {
         case Some((2, n)) if n <= 12 =>
-          List(compilerPlugin("org.scalamacros" % "paradise" % "2.1.1" cross CrossVersion.full))
+          List(compilerPlugin("org.scalamacros" % "paradise" % Versions.paradise cross CrossVersion.full))
         case _ =>
           Nil
       }
@@ -178,7 +183,7 @@ val jsonapiGeneric = projectMatrix
     libraryDependencies ++= {
       if (virtualAxes.value.contains(VirtualAxis.js)) {
         // This is insecure, but it used for unit testing only.
-        Seq("org.scala-js" %%% "scalajs-fake-insecure-java-securerandom" % "1.0.0" % Test)
+        Seq("org.scala-js" %%% "scalajs-fake-insecure-java-securerandom" % Versions.secureRandom % Test)
       } else
         Seq.empty
     }

--- a/jsonGeneric/src/main/scala/org/scalawag/bateman/json/generic/decoding/JSource.scala
+++ b/jsonGeneric/src/main/scala/org/scalawag/bateman/json/generic/decoding/JSource.scala
@@ -36,6 +36,8 @@ trait JSourceLike {
 
   def unexpectedValue(name: String): UnexpectedValue =
     UnexpectedValue(getFieldSourceUnsafe(name))
+
+  override def toString: String = s"JSource: ${root.toEncoding.spaces2}"
 }
 
 final case class JSource(root: JObject, fields: Map[String, JPointer] = Map.empty) extends JSourceLike

--- a/jsonGeneric/src/main/scala/org/scalawag/bateman/json/generic/semiauto/Derivers.scala
+++ b/jsonGeneric/src/main/scala/org/scalawag/bateman/json/generic/semiauto/Derivers.scala
@@ -30,6 +30,7 @@ import org.scalawag.bateman.json.generic.encoding.{
   TraitEncoderFactory
 }
 import shapeless.Lazy
+import shapeless.Lazy.mkLazy
 
 object Derivers {
 
@@ -38,7 +39,7 @@ object Derivers {
         discriminatorField: OptionLike[String] = None,
         config: OptionLike[Config] = None
     )(implicit
-        encoderFactory: Lazy[TraitEncoderFactory[A]],
+        encoderFactory: Lazy[TraitEncoderFactory[A]] = mkLazy,
         defaultConfig: Config = Config.default
     ): TraitEncoder[A] =
       encoderFactory.value(discriminatorField, config.value.getOrElse(defaultConfig))
@@ -49,7 +50,7 @@ object Derivers {
         discriminatorValue: OptionLike[String] = None,
         config: OptionLike[Config] = None
     )(implicit
-        encoderFactory: Lazy[CaseClassEncoderFactory[A]],
+        encoderFactory: Lazy[CaseClassEncoderFactory[A]] = mkLazy,
         defaultConfig: Config = Config.default
     ): CaseClassEncoder[A] =
       encoderFactory.value(discriminatorValue.value, config.value.getOrElse(defaultConfig))
@@ -60,7 +61,7 @@ object Derivers {
         discriminatorField: OptionLike[String] = None,
         config: OptionLike[Config] = None
     )(implicit
-        decoderFactory: Lazy[TraitDecoderFactory[A, Context]],
+        decoderFactory: Lazy[TraitDecoderFactory[A, Context]] = mkLazy,
         defaultConfig: Config = Config.default
     ): TraitDecoder[A, Context] =
       decoderFactory.value(discriminatorField, config.value.getOrElse(defaultConfig))
@@ -71,7 +72,7 @@ object Derivers {
         discriminatorValue: OptionLike[String] = None,
         config: OptionLike[Config] = None
     )(implicit
-        decoderFactory: Lazy[CaseClassDecoderFactory[A, Context]],
+        decoderFactory: Lazy[CaseClassDecoderFactory[A, Context]] = mkLazy,
         defaultConfig: Config = Config.default
     ): CaseClassDecoder[A, Context] =
       decoderFactory.value(discriminatorValue.value, config.value.getOrElse(defaultConfig))
@@ -82,8 +83,8 @@ object Derivers {
         discriminatorField: OptionLike[String] = None,
         config: OptionLike[Config] = None
     )(implicit
-        encoderFactory: Lazy[TraitEncoderFactory[A]],
-        decoderFactory: Lazy[TraitDecoderFactory[A, Context]],
+        encoderFactory: Lazy[TraitEncoderFactory[A]] = mkLazy,
+        decoderFactory: Lazy[TraitDecoderFactory[A, Context]] = mkLazy,
         defaultConfig: Config = Config.default
     ): TraitCodec[A, Context] =
       TraitCodec(
@@ -97,8 +98,8 @@ object Derivers {
         discriminatorValue: OptionLike[String] = None,
         config: OptionLike[Config] = None
     )(implicit
-        encoderFactory: Lazy[CaseClassEncoderFactory[A]],
-        decoderFactory: Lazy[CaseClassDecoderFactory[A, Context]],
+        encoderFactory: Lazy[CaseClassEncoderFactory[A]] = mkLazy,
+        decoderFactory: Lazy[CaseClassDecoderFactory[A, Context]] = mkLazy,
         defaultConfig: Config = Config.default
     ): CaseClassCodec[A, Context] =
       CaseClassCodec(

--- a/jsonapi/src/main/scala/org/scalawag/bateman/jsonapi/decoding/Attributes.scala
+++ b/jsonapi/src/main/scala/org/scalawag/bateman/jsonapi/decoding/Attributes.scala
@@ -17,12 +17,17 @@ package org.scalawag.bateman.jsonapi.decoding
 import cats.syntax.apply._
 import org.scalawag.bateman.json.decoding.{DecodeResult, Decoder, JAny, JObject, JString}
 import org.scalawag.bateman.json.encoding
+import org.scalawag.bateman.json.syntax.RichBateman
+
+import scala.util.Try
 
 final case class Attributes(src: JObject, mappings: Map[JString, JAny]) {
   private val bareMap: Map[String, JAny] = mappings.map { case (k, v) => k.value -> v }
   def get(key: String): Option[JAny] = bareMap.get(key)
 
   def toEncoding: Map[String, encoding.JAny] = mappings map { case (k, v) => k.value -> v.toEncoding }
+
+  override def toString: String = s"Attributes: ${Try(toEncoding.toJAny.spaces2).getOrElse(super.toString())}"
 }
 
 object Attributes {

--- a/jsonapi/src/main/scala/org/scalawag/bateman/jsonapi/decoding/Data.scala
+++ b/jsonapi/src/main/scala/org/scalawag/bateman/jsonapi/decoding/Data.scala
@@ -19,18 +19,11 @@ import cats.syntax.validated._
 import cats.syntax.traverse._
 import org.scalawag.bateman.json.{NotNull, Null, Nullable}
 import org.scalawag.bateman.json.syntax._
-import org.scalawag.bateman.json.decoding.{
-  DecodeResult,
-  Decoder,
-  JAny,
-  JArray,
-  JNull,
-  JObject,
-  JsonTypeMismatch,
-  UnspecifiedField
-}
+import org.scalawag.bateman.json.decoding.{DecodeResult, Decoder, JAny, JArray, JNull, JObject, JsonTypeMismatch, UnspecifiedField}
 import org.scalawag.bateman.json.generic.decoding.JSource
 import org.scalawag.bateman.jsonapi.encoding
+
+import scala.util.Try
 
 trait Data[+A] {
   val src: JAny
@@ -79,6 +72,8 @@ trait PluralData[A] extends Data[A] {
 
 sealed trait PrimaryData extends Data[ResourceLike] {
   def toEncoding: encoding.PrimaryData
+
+  override def toString: String = Try(toEncoding.toString).getOrElse(super.toString())
 }
 
 object PrimaryData {
@@ -118,6 +113,8 @@ object PrimaryData {
 
 sealed trait RelationshipData extends Data[ResourceIdentifier] {
   def toEncoding: encoding.RelationshipData
+
+  override def toString: String = Try(toEncoding.toString).getOrElse(super.toString())
 }
 
 object RelationshipData {
@@ -137,6 +134,8 @@ case class ResourceIdentifierData(src: JAny, data: ResourceIdentifier)
     with RelationshipData {
   override def toEncoding: encoding.ResourceIdentifierData =
     encoding.ResourceIdentifierData(data.toEncoding)
+
+  override def toString: String = Try(toEncoding.toString).getOrElse(super.toString())
 }
 
 object ResourceIdentifierData {
@@ -150,6 +149,7 @@ case class ResourceObjectData(src: JAny, data: ResourceObject) extends SingularD
   override def toEncoding: encoding.ResourceObjectData =
     encoding.ResourceObjectData(data.toEncoding)
 
+  override def toString: String = Try(toEncoding.toString).getOrElse(super.toString())
 }
 
 object ResourceObjectData {
@@ -164,6 +164,8 @@ case class ResourceObjectOptionalIdData(src: JAny, data: ResourceObjectOptionalI
     with PrimaryData {
   override def toEncoding: encoding.ResourceObjectOptionalIdData =
     encoding.ResourceObjectOptionalIdData(data.toEncoding)
+
+  override def toString: String = Try(toEncoding.toString).getOrElse(super.toString())
 }
 
 object ResourceObjectOptionalIdData {
@@ -179,6 +181,8 @@ case class ResourceIdentifiersData(src: JArray, data: List[ResourceIdentifier])
     with RelationshipData {
   override def toEncoding: encoding.ResourceIdentifiersData =
     encoding.ResourceIdentifiersData(data.map(_.toEncoding))
+
+  override def toString: String = Try(toEncoding.toString).getOrElse(super.toString())
 }
 
 object ResourceIdentifiersData {
@@ -193,6 +197,8 @@ case class ResourceObjectsData(src: JArray, data: List[ResourceObject])
     with PrimaryData {
   override def toEncoding: encoding.ResourceObjectsData =
     encoding.ResourceObjectsData(data.map(_.toEncoding))
+
+  override def toString: String = Try(toEncoding.toString).getOrElse(super.toString())
 }
 
 object ResourceObjectsData {

--- a/jsonapi/src/main/scala/org/scalawag/bateman/jsonapi/decoding/Document.scala
+++ b/jsonapi/src/main/scala/org/scalawag/bateman/jsonapi/decoding/Document.scala
@@ -25,6 +25,8 @@ import org.scalawag.bateman.json.validIfEmpty
 import org.scalawag.bateman.jsonapi.encoding
 import shapeless.tag.@@
 
+import scala.util.Try
+
 // None for all these Options means that the key didn't appear in the document. If they're set to "null" or empty,
 // they will have a Some.
 
@@ -136,6 +138,8 @@ final case class Document(
     import org.scalawag.bateman.jsonapi.query
     dtquery[List, To](_ ~> query.data ~> query.multiple ~> as[To])
   }
+
+  override def toString: String = Try(toEncoding.toString).getOrElse(super.toString())
 }
 
 case object Document {
@@ -148,6 +152,8 @@ final case class Jsonapi(
     meta: Option[Meta] = None
 ) {
   def toEncoding: encoding.Jsonapi = encoding.Jsonapi(version = version.map(_.value), meta = meta.map(_.toEncoding))
+
+  override def toString: String = Try(toEncoding.toString).getOrElse(super.toString())
 }
 
 object Jsonapi {

--- a/jsonapi/src/main/scala/org/scalawag/bateman/jsonapi/decoding/Error.scala
+++ b/jsonapi/src/main/scala/org/scalawag/bateman/jsonapi/decoding/Error.scala
@@ -20,6 +20,8 @@ import org.scalawag.bateman.json.generic.{SourceTag, semiauto}
 import org.scalawag.bateman.jsonapi.encoding
 import shapeless.tag.@@
 
+import scala.util.Try
+
 final case class ErrorSource(
     src: JSource @@ SourceTag,
     pointer: Option[JString] = None,
@@ -30,6 +32,8 @@ final case class ErrorSource(
       pointer = pointer.map(_.value),
       parameter = parameter.map(_.value)
     )
+
+  override def toString: String = Try(toEncoding.toString).getOrElse(super.toString())
 }
 
 object ErrorSource {
@@ -58,6 +62,8 @@ final case class Error(
       source = source.map(_.toEncoding),
       meta = meta.map(_.toEncoding)
     )
+
+  override def toString: String = Try(toEncoding.toString).getOrElse(super.toString())
 }
 
 object Error {

--- a/jsonapi/src/main/scala/org/scalawag/bateman/jsonapi/decoding/Errors.scala
+++ b/jsonapi/src/main/scala/org/scalawag/bateman/jsonapi/decoding/Errors.scala
@@ -19,8 +19,12 @@ import org.scalawag.bateman.json.syntax._
 import org.scalawag.bateman.json.decoding.{DecodeResult, Decoder, JArray}
 import org.scalawag.bateman.jsonapi.encoding
 
+import scala.util.Try
+
 final case class Errors(src: JArray, errors: List[Error]) {
   def toEncoding: List[encoding.Error] = errors.map(_.toEncoding)
+
+  override def toString: String = s"Errors: ${Try(toEncoding.toJAny.spaces2).getOrElse(super.toString())}"
 }
 
 object Errors {

--- a/jsonapi/src/main/scala/org/scalawag/bateman/jsonapi/decoding/Link.scala
+++ b/jsonapi/src/main/scala/org/scalawag/bateman/jsonapi/decoding/Link.scala
@@ -20,6 +20,8 @@ import org.scalawag.bateman.json.generic.{SourceTag, semiauto}
 import org.scalawag.bateman.jsonapi.encoding
 import shapeless.tag.@@
 
+import scala.util.Try
+
 sealed trait Link {
   def toEncoding: encoding.Link
 }
@@ -38,6 +40,8 @@ final case class BareLink(href: JString) extends Link {
     encoding.BareLink(
       href = href.value
     )
+
+  override def toString: String = Try(toEncoding.toString).getOrElse(super.toString())
 }
 
 object BareLink {
@@ -54,6 +58,8 @@ final case class RichLink(src: JSource @@ SourceTag, href: Option[JString] = Non
       href = href.map(_.value),
       meta = meta.map(_.toEncoding)
     )
+
+  override def toString: String = Try(toEncoding.toString).getOrElse(super.toString())
 }
 
 object RichLink {

--- a/jsonapi/src/main/scala/org/scalawag/bateman/jsonapi/decoding/Links.scala
+++ b/jsonapi/src/main/scala/org/scalawag/bateman/jsonapi/decoding/Links.scala
@@ -21,11 +21,15 @@ import org.scalawag.bateman.json.decoding.{DecodeResult, Decoder, JObject, JStri
 import org.scalawag.bateman.json.generic.decoding.JSource
 import org.scalawag.bateman.jsonapi.encoding
 
+import scala.util.Try
+
 final case class Links(src: JObject, mappings: Map[JString, Link]) {
   private val bareMap: Map[String, Link] = mappings.map { case (k, v) => k.value -> v }
   def get(key: String): Option[Link] = bareMap.get(key)
 
   def toEncoding: Map[String, encoding.Link] = mappings map { case (k, v) => k.value -> v.toEncoding }
+
+  override def toString: String = s"Links: ${Try(toEncoding.toJAny.spaces2).getOrElse(super.toString())}"
 }
 
 object Links {

--- a/jsonapi/src/main/scala/org/scalawag/bateman/jsonapi/decoding/Meta.scala
+++ b/jsonapi/src/main/scala/org/scalawag/bateman/jsonapi/decoding/Meta.scala
@@ -21,11 +21,15 @@ import org.scalawag.bateman.json.decoding.{DecodeResult, Decoder, JAny, JObject,
 import org.scalawag.bateman.json.encoding
 import org.scalawag.bateman.json.generic.decoding.JSource
 
+import scala.util.Try
+
 final case class Meta(src: JObject, mappings: Map[JString, JAny]) {
   private val bareMap: Map[String, JAny] = mappings.map { case (k, v) => k.value -> v }
   def get(key: String): Option[JAny] = bareMap.get(key)
 
   def toEncoding: Map[String, encoding.JAny] = mappings map { case (k, v) => k.value -> v.toEncoding }
+
+  override def toString: String = s"Meta: ${Try(toEncoding.toJAny.spaces2).getOrElse(super.toString())}"
 }
 
 object Meta {

--- a/jsonapi/src/main/scala/org/scalawag/bateman/jsonapi/decoding/Relationship.scala
+++ b/jsonapi/src/main/scala/org/scalawag/bateman/jsonapi/decoding/Relationship.scala
@@ -20,6 +20,8 @@ import org.scalawag.bateman.json.generic.{SourceTag, semiauto}
 import org.scalawag.bateman.jsonapi.encoding
 import shapeless.tag.@@
 
+import scala.util.Try
+
 final case class Relationship(
     src: JSource @@ SourceTag,
     data: Option[RelationshipData] = None,
@@ -34,6 +36,8 @@ final case class Relationship(
       meta = meta.map(_.toEncoding),
       links = links.map(_.toEncoding)
     )
+
+  override def toString: String = Try(toEncoding.toString).getOrElse(super.toString)
 }
 
 object Relationship {

--- a/jsonapi/src/main/scala/org/scalawag/bateman/jsonapi/decoding/Relationships.scala
+++ b/jsonapi/src/main/scala/org/scalawag/bateman/jsonapi/decoding/Relationships.scala
@@ -19,11 +19,15 @@ import org.scalawag.bateman.json.syntax._
 import org.scalawag.bateman.json.decoding.{DecodeResult, Decoder, JAny, JObject, JString}
 import org.scalawag.bateman.jsonapi.encoding
 
+import scala.util.Try
+
 final case class Relationships(src: JObject, mappings: Map[JString, Relationship]) {
   private val bareMap: Map[String, Relationship] = mappings.map { case (k, v) => k.value -> v }
   def get(key: String): Option[Relationship] = bareMap.get(key)
 
   def toEncoding: Map[String, encoding.Relationship] = mappings map { case (k, v) => k.value -> v.toEncoding }
+
+  override def toString: String = s"Relationships: ${Try(toEncoding.toJAny.spaces2).getOrElse(super.toString())}"
 }
 
 object Relationships {

--- a/jsonapi/src/main/scala/org/scalawag/bateman/jsonapi/decoding/ResourceLike.scala
+++ b/jsonapi/src/main/scala/org/scalawag/bateman/jsonapi/decoding/ResourceLike.scala
@@ -18,23 +18,14 @@ import cats.syntax.validated._
 import cats.syntax.traverse._
 import cats.syntax.apply._
 import org.scalawag.bateman.json.syntax._
-import org.scalawag.bateman.json.decoding.{
-  DecodeResult,
-  Decoder,
-  JAny,
-  JAnyDecoder,
-  JObject,
-  JPointer,
-  JString,
-  JsonTypeMismatch,
-  UnexpectedValue,
-  UnspecifiedField
-}
+import org.scalawag.bateman.json.decoding.{DecodeResult, Decoder, JAny, JAnyDecoder, JObject, JPointer, JString, JsonTypeMismatch, UnexpectedValue, UnspecifiedField}
 import org.scalawag.bateman.json.generic.decoding.JSource
 import org.scalawag.bateman.json.generic.{SourceTag, semiauto}
 import org.scalawag.bateman.json.{ProgrammerError, validIfEmpty}
 import org.scalawag.bateman.jsonapi.encoding
 import shapeless.tag.@@
+
+import scala.util.Try
 
 sealed trait ResourceLike extends HasMeta {
   val src: JSource
@@ -221,6 +212,8 @@ final case class ResourceObject(
       meta = meta.map(_.toEncoding),
       links = links.map(_.toEncoding)
     )
+
+  override def toString: String = Try(toEncoding.toString).getOrElse(super.toString())
 }
 
 object ResourceObject {

--- a/jsonapi/src/main/scala/org/scalawag/bateman/jsonapi/encoding/Document.scala
+++ b/jsonapi/src/main/scala/org/scalawag/bateman/jsonapi/encoding/Document.scala
@@ -15,19 +15,12 @@
 package org.scalawag.bateman.jsonapi.encoding
 
 import org.scalawag.bateman.jsonapi.encoding
-import org.scalawag.bateman.json.encoding.{
-  Encoder,
-  JAny,
-  JAnyEncoder,
-  JArray,
-  JArrayEncoder,
-  JNull,
-  JObject,
-  JObjectEncoder,
-  JStringEncoder
-}
+import org.scalawag.bateman.json.encoding.{Encoder, JAny, JAnyEncoder, JArray, JArrayEncoder, JNull, JObject, JObjectEncoder, JStringEncoder}
 import org.scalawag.bateman.json.generic.semiauto
 import cats.syntax.contravariant._
+import org.scalawag.bateman.jsonapi.encoding.ResourceObject.encoder
+
+import scala.util.Try
 
 sealed trait HasMeta[A] {
   def meta: Option[Map[String, JAny]]
@@ -48,7 +41,9 @@ object Link {
 
 final case class BareLink(
     href: String
-) extends Link
+) extends Link {
+  override def toString: String = s"BareLink: ${Try(BareLink.encoder.encode(this).spaces2).getOrElse(super.toString())}"
+}
 
 object BareLink {
   implicit val encoder: Encoder[BareLink, JAny] = JStringEncoder[String].contramap(_.href)
@@ -60,6 +55,8 @@ final case class RichLink(
 ) extends Link
     with HasMeta[RichLink] {
   override def mapMeta(fn: Option[Map[String, JAny]] => Option[Map[String, JAny]]): RichLink = copy(meta = fn(meta))
+
+  override def toString: String = s"RichLink: ${Try(RichLink.encoder.encode(this).spaces2).getOrElse(super.toString())}"
 }
 
 object RichLink {
@@ -69,7 +66,9 @@ object RichLink {
 final case class ErrorSource(
     pointer: Option[String] = None,
     parameter: Option[String] = None
-)
+) {
+  override def toString: String = s"ErrorSource: ${Try(ErrorSource.encoder.encode(this).spaces2).getOrElse(super.toString())}"
+}
 
 object ErrorSource {
   implicit val encoder: JObjectEncoder[ErrorSource] = semiauto.deriveEncoderForCaseClass[ErrorSource]()
@@ -86,6 +85,8 @@ final case class Error(
     meta: Option[Map[String, JAny]] = None
 ) extends HasMeta[Error] {
   override def mapMeta(fn: Option[Map[String, JAny]] => Option[Map[String, JAny]]): Error = copy(meta = fn(meta))
+
+  override def toString: String = s"Error: ${Try(Error.encoder.encode(this).spaces2).getOrElse(super.toString())}"
 }
 
 object Error {
@@ -95,7 +96,9 @@ object Error {
 final case class Jsonapi(
     version: Option[String] = None,
     meta: Option[Map[String, JAny]] = None
-)
+) {
+  override def toString: String = s"Jsonapi: ${Try(Jsonapi.encoder.encode(this).spaces2).getOrElse(super.toString())}"
+}
 
 object Jsonapi {
   implicit val encoder: Encoder[Jsonapi, JObject] = semiauto.deriveEncoderForCaseClass[Jsonapi]()
@@ -103,7 +106,9 @@ object Jsonapi {
 
 sealed trait Data
 
-sealed trait PrimaryData extends Data
+sealed trait PrimaryData extends Data {
+  override def toString: String = s"PrimaryData: ${Try(PrimaryData.encoder.encode(this).spaces2).getOrElse(super.toString())}"
+}
 
 object PrimaryData {
   // These make it possible to create a PrimaryData without having to use the specific Data.* constructor
@@ -127,7 +132,9 @@ object PrimaryData {
   }
 }
 
-sealed trait RelationshipData extends Data
+sealed trait RelationshipData extends Data {
+  override def toString: String = s"RelationshipData: ${Try(RelationshipData.encoder.encode(this).spaces2).getOrElse(super.toString())}"
+}
 
 object RelationshipData {
   // These make it possible to create a RelationshipData without having to use the specific *Data constructor
@@ -148,35 +155,45 @@ case object NullData extends NullData {
   implicit def encoder: Encoder[NullData, JAny] = Encoder { _ => JNull }
 }
 
-case class ResourceIdentifierData(data: encoding.ResourceIdentifier) extends PrimaryData with RelationshipData
+case class ResourceIdentifierData(data: encoding.ResourceIdentifier) extends PrimaryData with RelationshipData {
+  override def toString: String = s"ResourceIdentifierData: ${Try(ResourceIdentifierData.encoder.encode(this).spaces2).getOrElse(super.toString())}"
+}
 
 object ResourceIdentifierData {
   implicit def encoder: Encoder[ResourceIdentifierData, JAny] =
     JAnyEncoder[encoding.ResourceIdentifier].contramap(_.data)
 }
 
-case class ResourceObjectData(data: encoding.ResourceObject) extends PrimaryData
+case class ResourceObjectData(data: encoding.ResourceObject) extends PrimaryData {
+  override def toString: String = s"ResourceObjectData: ${Try(ResourceObjectData.encoder.encode(this).spaces2).getOrElse(super.toString())}"
+}
 
 object ResourceObjectData {
   implicit def encoder: Encoder[ResourceObjectData, JAny] =
     JAnyEncoder[encoding.ResourceObject].contramap(_.data)
 }
 
-case class ResourceObjectOptionalIdData(data: encoding.ResourceObjectOptionalId) extends PrimaryData
+case class ResourceObjectOptionalIdData(data: encoding.ResourceObjectOptionalId) extends PrimaryData {
+  override def toString: String = s"ResourceObjectOptionalIdData: ${Try(ResourceObjectOptionalIdData.encoder.encode(this).spaces2).getOrElse(super.toString())}"
+}
 
 object ResourceObjectOptionalIdData {
   implicit def encoder: Encoder[ResourceObjectOptionalIdData, JAny] =
     JAnyEncoder[encoding.ResourceObjectOptionalId].contramap(_.data)
 }
 
-case class ResourceIdentifiersData(data: List[encoding.ResourceIdentifier]) extends PrimaryData with RelationshipData
+case class ResourceIdentifiersData(data: List[encoding.ResourceIdentifier]) extends PrimaryData with RelationshipData {
+  override def toString: String = s"ResourceIdentifiersData: ${Try(ResourceIdentifiersData.encoder.encode(this).spaces2).getOrElse(super.toString())}"
+}
 
 object ResourceIdentifiersData {
   implicit def encoder: Encoder[ResourceIdentifiersData, JArray] =
     JArrayEncoder[List[encoding.ResourceIdentifier]].contramap(_.data)
 }
 
-case class ResourceObjectsData(data: List[encoding.ResourceObject]) extends PrimaryData
+case class ResourceObjectsData(data: List[encoding.ResourceObject]) extends PrimaryData {
+  override def toString: String = s"ResourceObjectsData: ${Try(ResourceObjectsData.encoder.encode(this).spaces2).getOrElse(super.toString())}"
+}
 
 object ResourceObjectsData {
   implicit def encoder: Encoder[ResourceObjectsData, JArray] =
@@ -189,6 +206,8 @@ final case class Relationship(
     links: Option[Map[String, Link]] = None
 ) extends HasMeta[Relationship] {
   override def mapMeta(fn: Option[Map[String, JAny]] => Option[Map[String, JAny]]): Relationship = copy(meta = fn(meta))
+
+  override def toString: String = s"Relationship: ${Try(Relationship.encoder.encode(this).spaces2).getOrElse(super.toString())}"
 }
 
 object Relationship {
@@ -212,6 +231,8 @@ final case class ResourceIdentifier(
     with HasMeta[ResourceIdentifier] {
   override def mapMeta(fn: Option[Map[String, JAny]] => Option[Map[String, JAny]]): ResourceIdentifier =
     copy(meta = fn(meta))
+
+  override def toString: String = s"ResourceIdentifier: ${Try(ResourceIdentifier.encoder.encode(this).spaces2).getOrElse(super.toString())}"
 }
 
 object ResourceIdentifier {
@@ -238,6 +259,8 @@ final case class ResourceObjectOptionalId(
 
   override def mapMeta(fn: Option[Map[String, JAny]] => Option[Map[String, JAny]]): ResourceObjectOptionalId =
     copy(meta = fn(meta))
+
+  override def toString: String = s"ResourceObjectOptionalId: ${Try(ResourceObjectOptionalId.encoder.encode(this).spaces2).getOrElse(super.toString())}"
 }
 
 object ResourceObjectOptionalId {
@@ -261,6 +284,8 @@ final case class ResourceObject(
     copy(meta = fn(meta))
 
   def getResourceIdentifier: ResourceIdentifier = ResourceIdentifier(this.`type`, this.id)
+
+  override def toString: String = s"ResourceObject: ${Try(ResourceObject.encoder.encode(this).spaces2).getOrElse(super.toString())}"
 }
 
 object ResourceObject {
@@ -313,6 +338,8 @@ final case class Document(
 
   def mapMeta(fn: Option[Map[String, JAny]] => Option[Map[String, JAny]]): Document =
     copy(disposition = disposition.mapMeta(fn))
+
+  override def toString: String = s"Document: ${Try(Document.encoder.encode(this).spaces2).getOrElse(super.toString())}"
 }
 
 case object Document {

--- a/jsonapi/src/test/scala/org/scalawag/bateman/jsonapi/ToStringTest.scala
+++ b/jsonapi/src/test/scala/org/scalawag/bateman/jsonapi/ToStringTest.scala
@@ -1,0 +1,172 @@
+package org.scalawag.bateman.jsonapi
+
+import cats.data.Validated
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
+import org.scalawag.bateman.jsonapi.decoding.{Attributes, Document, Errors, ResourceObjectData}
+import org.scalawag.bateman.json.decoding.query._
+import org.scalawag.bateman.json.ParserTestUtils
+import org.scalawag.bateman.json.decoding.query.Query._
+
+class ToStringTest extends AnyFunSpec with Matchers with ParserTestUtils {
+  it("converts a ResourceObject to a String") {
+    val d = parseAs[Document]("""
+      {
+        "data": {
+          "type": "my_class",
+          "id": "ID",
+          "attributes": {
+            "a": "A",
+            "b": "B"
+          }
+        }
+      }
+    """)
+
+    val resourceObject = d.data.collect { case ResourceObjectData(_, r) => r }.getOrElse(fail("Document in ResourceObject toString test was not a ResourceObject."))
+
+    val desiredString = """
+      |ResourceObject: {
+      |  "type": "my_class",
+      |  "id": "ID",
+      |  "attributes": {
+      |    "a": "A",
+      |    "b": "B"
+      |  }
+      |}
+      |""".stripMargin.stripLeading().stripTrailing()
+
+    resourceObject.toString() shouldBe desiredString
+    resourceObject.toEncoding.toString() shouldBe desiredString
+  }
+
+  it("converts a Document to a String") {
+    val d = parseAs[Document](
+      """
+      {
+        "data": {
+          "type": "my_class",
+          "id": "ID",
+          "attributes": {
+            "a": "A",
+            "b": "B"
+          }
+        }
+      }
+    """)
+
+    val desiredString =
+      """
+        |Document: {
+        |  "data": {
+        |    "type": "my_class",
+        |    "id": "ID",
+        |    "attributes": {
+        |      "a": "A",
+        |      "b": "B"
+        |    }
+        |  }
+        |}
+        |""".stripMargin.stripLeading().stripTrailing()
+
+    d.toString() shouldBe desiredString
+    d.toEncoding.toString() shouldBe desiredString
+  }
+
+  it("converts Attributes to a String") {
+    val d = parseAs[Document]("""
+      {
+        "data": {
+          "type": "my_class",
+          "id": "ID",
+          "attributes": {
+            "a": "A",
+            "b": "B"
+          }
+        }
+      }
+    """)
+
+    val desiredString =
+      """
+        |Attributes: {
+        |  "a": "A",
+        |  "b": "B"
+        |}
+        |""".stripMargin.stripLeading().stripTrailing()
+
+
+    d.src.root.query(_ ~> "data" ~> "attributes" ~> as[Attributes]) match {
+      case Validated.Valid(attributes) =>
+        attributes.toString shouldBe desiredString
+
+      case Validated.Invalid(e) => fail(s"Document in Attributes toString test did not contain data.attributes: $e")
+    }
+  }
+
+  it("converts Errors to a String") {
+    val d = parseAs[Document]("""
+      {
+        "errors": [
+          {
+            "status": "400",
+            "code": "invalid_include_path",
+            "detail": "The include path 'hello' is invalid.",
+            "source": {
+              "parameter": "include"
+            },
+            "meta": {
+              "path": "hello"
+            }
+          },
+          {
+            "status": "400",
+            "code": "invalid_include_path",
+            "detail": "The include path 'world' is invalid.",
+            "source": {
+              "parameter": "include"
+            },
+            "meta": {
+              "path": "hello"
+            }
+          }
+        ]
+      }
+    """)
+
+    val desiredString =
+      """
+        |Errors: [
+        |  {
+        |    "status": "400",
+        |    "code": "invalid_include_path",
+        |    "detail": "The include path 'hello' is invalid.",
+        |    "source": {
+        |      "parameter": "include"
+        |    },
+        |    "meta": {
+        |      "path": "hello"
+        |    }
+        |  },
+        |  {
+        |    "status": "400",
+        |    "code": "invalid_include_path",
+        |    "detail": "The include path 'world' is invalid.",
+        |    "source": {
+        |      "parameter": "include"
+        |    },
+        |    "meta": {
+        |      "path": "hello"
+        |    }
+        |  }
+        |]
+        |""".stripMargin.stripLeading().stripTrailing()
+
+    d.src.root.query(_ ~> "errors" ~> as[Errors]) match {
+      case Validated.Valid(errors) =>
+        errors.toString() shouldBe desiredString
+
+      case Validated.Invalid(e) => fail("Document in Errors toString test was not Errors")
+    }
+  }
+}

--- a/jsonapiGeneric/src/test/scala/org/scalawag/bateman/jsonapi/generic/decoding/JSourceTest.scala
+++ b/jsonapiGeneric/src/test/scala/org/scalawag/bateman/jsonapi/generic/decoding/JSourceTest.scala
@@ -1,0 +1,39 @@
+package org.scalawag.bateman.jsonapi.generic.decoding
+
+import cats.data.Validated
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
+import org.scalawag.bateman.json.ParserTestUtils
+import org.scalawag.bateman.json.decoding.query.as
+import org.scalawag.bateman.json.generic.SourceTag
+import org.scalawag.bateman.jsonapi.decoding.Document
+import org.scalawag.bateman.jsonapi.{decoding, encoding}
+import org.scalawag.bateman.jsonapi.generic.{AttributeTag, IdTag, semiauto}
+import org.scalawag.bateman.jsonapi.query.{data, required}
+import shapeless.tag.@@
+
+class JSourceTest extends AnyFunSpec with Matchers with ParserTestUtils {
+  it("should convert to a String") {
+    case class AffiniHoodie(id: String @@ IdTag, size: String @@ AttributeTag, limitedEdition: Boolean @@ AttributeTag, color: String @@ AttributeTag, json: Option[JSource] @@ SourceTag = None)
+    val codec = semiauto.deriveResourceObjectCodecForCaseClass[AffiniHoodie]("affinihoodie")
+    val affiniHoodie = AffiniHoodie(id = "affinifan-78", size = "M", limitedEdition = true, color = "grey")
+    val encodingResourceObject = codec.encoder.encode(affiniHoodie)
+    val stringifiedHoodie = encoding.ResourceObject.encoder.encode(encodingResourceObject).render
+    val decodingResourceObject = parseAs[decoding.ResourceObject](stringifiedHoodie)
+
+    val desiredString =
+      """
+        |JSource: {
+        |  "type": "affinihoodie",
+        |  "id": "affinifan-78",
+        |  "attributes": {
+        |    "color": "grey",
+        |    "limitedEdition": true,
+        |    "size": "M"
+        |  }
+        |}
+        |""".stripMargin.stripLeading().stripTrailing()
+
+    decodingResourceObject.src.toString shouldBe desiredString
+  }
+}

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -28,7 +28,7 @@ addSbtPlugin("ch.epfl.scala" % "sbt-version-policy" % "2.0.1")
 addSbtPlugin("com.typesafe" % "sbt-mima-plugin" % "1.1.1")
 addSbtPlugin("org.scalawag.sbt" % "sbt-git-flux" % "0.0.2")
 addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.11.0")
-addSbtPlugin("org.scala-js" % "sbt-scalajs" % "1.11.0")
+addSbtPlugin("org.scala-js" % "sbt-scalajs" % "1.13.0")
 
 addSbtPlugin("org.scalawag.sbt" %% "sbt-build-metadata" % "0.1.0-pre.2")
 


### PR DESCRIPTION
Make toStrings readable and useful by outputting JSON instead of a list of paths. In the event that an encoder fails, toString behavior will fall back to current behavior.

Update dependencies.

Revert Circe to 0.14.1 to maintain compatibility with downstream consumers.

Default Lazy factories to shapeless.Lazy.mkLazy. Downstream consumers did not use mkLazy as an implicit even after importing mkLazy, even though they did with Bateman 0.1.x. Thus, I have added a default here.

Add tests to confirm toString output.

Please create a new release if/when this is merged.