### PR TITLE
update dependencies and resolve warnings

### DIFF
--- a/bateman_2.diff
+++ b/bateman_2.diff
@@ -1,0 +1,13 @@
+diff --git a/build.sbt b/build.sbt
+index 6b690e3..cb2be15 100644
+--- a/build.sbt
++++ b/build.sbt
+@@ -21,7 +21,7 @@ ThisBuild / organization := "org.scalawag.bateman"
+ 
+ val Versions = new Object {
+   val cats = "2.9.0"
+-  val circe = "0.14.1"
++  val circe = "0.14.5"
+   val enumeratum = "1.7.0"
+   val fastparse = "2.3.3"
+   val scalatest = "3.2.15"

--- a/build.sbt
+++ b/build.sbt
@@ -21,7 +21,7 @@ ThisBuild / organization := "org.scalawag.bateman"
 
 val Versions = new Object {
   val cats = "2.9.0"
-  val circe = "0.14.1"
+  val circe = "0.14.5"
   val enumeratum = "1.7.0"
   val fastparse = "2.3.3"
   val scalatest = "3.2.15"

--- a/build.sbt
+++ b/build.sbt
@@ -20,22 +20,27 @@ ThisBuild / versionScheme := Some("early-semver")
 ThisBuild / organization := "org.scalawag.bateman"
 
 val Versions = new Object {
-  val cats = "2.8.0"
-  val circe = "0.14.3"
+  val cats = "2.9.0"
+  val circe = "0.14.1"
   val enumeratum = "1.7.0"
   val fastparse = "2.3.3"
-  val scalatest = "3.2.14"
+  val scalatest = "3.2.15"
   val shapeless = "2.3.10"
   val scalacheck = "1.17.0"
+  val scalaJavaTime = "2.5.0"
+  val secureRandom = "1.0.0"
+  val paradise = "2.1.1"
+  val collectionCompat = "2.9.0"
+  val kindProjector = "0.13.2"
 }
 
-val jvmScalaVersions = Seq("2.12.17", "2.13.9")
+val jvmScalaVersions = Seq("2.12.17", "2.13.10")
 val jsScalaVersions = jvmScalaVersions
 
 val commonSettings = Seq(
   organization := "org.scalawag.bateman",
 //  scalacOptions += "-Xlog-implicits",
-  addCompilerPlugin("org.typelevel" % "kind-projector" % "0.13.2" cross CrossVersion.full),
+  addCompilerPlugin("org.typelevel" % "kind-projector" % Versions.kindProjector cross CrossVersion.full),
   scalacOptions ++= Seq(
     "-language:higherKinds",
     "-language:implicitConversions",
@@ -89,12 +94,12 @@ val json = projectMatrix
     name := s"$projectBaseName-json",
     libraryDependencies ++= Seq(
       "org.typelevel" %%% "cats-core" % Versions.cats,
-      "org.scala-lang.modules" %%% "scala-collection-compat" % "2.7.0",
-      "io.github.cquiroz" %%% "scala-java-time" % "2.2.2",
+      "org.scala-lang.modules" %%% "scala-collection-compat" % Versions.collectionCompat,
+      "io.github.cquiroz" %%% "scala-java-time" % Versions.scalaJavaTime,
       "org.typelevel" %% "cats-core" % Versions.cats,
     ),
     libraryDependencies ++= Seq(
-      "io.github.cquiroz" %%% "scala-java-time" % "2.2.2"
+      "io.github.cquiroz" %%% "scala-java-time" % Versions.scalaJavaTime
     ).map(_ % Test)
   )
   .jvmPlatform(scalaVersions = jvmScalaVersions)
@@ -130,7 +135,7 @@ val jsonGeneric = projectMatrix
     libraryDependencies ++= {
       CrossVersion.partialVersion(scalaVersion.value) match {
         case Some((2, n)) if n <= 12 =>
-          List(compilerPlugin("org.scalamacros" % "paradise" % "2.1.1" cross CrossVersion.full))
+          List(compilerPlugin("org.scalamacros" % "paradise" % Versions.paradise cross CrossVersion.full))
         case _ =>
           Nil
       }
@@ -146,12 +151,12 @@ val jsonLiteral = projectMatrix
     name := s"$projectBaseName-json-literal",
     libraryDependencies ++= Seq(
       "org.scala-lang" % "scala-reflect" % scalaVersion.value,
-      "io.github.cquiroz" %%% "scala-java-time" % "2.2.2" % Test,
+      "io.github.cquiroz" %%% "scala-java-time" % Versions.scalaJavaTime % Test,
     ),
     libraryDependencies ++= {
       CrossVersion.partialVersion(scalaVersion.value) match {
         case Some((2, n)) if n <= 12 =>
-          List(compilerPlugin("org.scalamacros" % "paradise" % "2.1.1" cross CrossVersion.full))
+          List(compilerPlugin("org.scalamacros" % "paradise" % Versions.paradise cross CrossVersion.full))
         case _ =>
           Nil
       }
@@ -178,7 +183,7 @@ val jsonapiGeneric = projectMatrix
     libraryDependencies ++= {
       if (virtualAxes.value.contains(VirtualAxis.js)) {
         // This is insecure, but it used for unit testing only.
-        Seq("org.scala-js" %%% "scalajs-fake-insecure-java-securerandom" % "1.0.0" % Test)
+        Seq("org.scala-js" %%% "scalajs-fake-insecure-java-securerandom" % Versions.secureRandom % Test)
       } else
         Seq.empty
     }

--- a/enumeratum/src/main/scala/org/scalawag/bateman/json/enumeratum/BatemanEnum.scala
+++ b/enumeratum/src/main/scala/org/scalawag/bateman/json/enumeratum/BatemanEnum.scala
@@ -27,14 +27,14 @@ trait BatemanEnum[A <: EnumEntry] { this: Enum[A] =>
 }
 
 object BatemanEnum {
-  def encoder[A <: EnumEntry](enum: Enum[A]): Encoder[A, encoding.JString] =
+  def encoder[A <: EnumEntry](`enum`: Enum[A]): Encoder[A, encoding.JString] =
     encoding.JStringEncoder[String].contramap(_.entryName)
 
-  def decoder[A <: EnumEntry](enum: Enum[A]): Decoder[decoding.JString, A] =
+  def decoder[A <: EnumEntry](`enum`: Enum[A]): Decoder[decoding.JString, A] =
     Decoder { in =>
-      enum.withNameOption(in.value) match {
+      `enum`.withNameOption(in.value) match {
         case Some(member) => member.validNec
-        case None         => InvalidValue(in, s"'${in.value}' is not a member of enum $enum").invalidNec
+        case None         => InvalidValue(in, s"'${in.value}' is not a member of enum ${`enum`}").invalidNec
       }
     }
 }

--- a/enumeratum/src/main/scala/org/scalawag/bateman/json/enumeratum/BatemanValueEnum.scala
+++ b/enumeratum/src/main/scala/org/scalawag/bateman/json/enumeratum/BatemanValueEnum.scala
@@ -33,19 +33,19 @@ sealed trait BatemanValueEnum[
 
 object BatemanValueEnum {
   def encoder[EncodingType <: encoding.JAny, ValueType, EntryType <: ValueEnumEntry[ValueType]](
-      enum: ValueEnum[ValueType, EntryType]
+      `enum`: ValueEnum[ValueType, EntryType]
   )(implicit valueEncoder: Encoder[ValueType, EncodingType]): Encoder[EntryType, EncodingType] = { entry =>
     valueEncoder.encode(entry.value)
   }
 
   def decoder[DecodingType <: decoding.JAny, ValueType, EntryType <: ValueEnumEntry[ValueType]](
-      enum: ValueEnum[ValueType, EntryType]
+      `enum`: ValueEnum[ValueType, EntryType]
   )(implicit valueDecoder: Decoder[DecodingType, ValueType]): Decoder[DecodingType, EntryType] =
     Decoder[DecodingType, EntryType] { in: DecodingType =>
       valueDecoder.decode(in).andThen { v =>
-        enum.withValueOpt(v) match {
+        `enum`.withValueOpt(v) match {
           case Some(member) => member.validNec
-          case None         => InvalidValue(in, s"$v is not a member of enum $enum").invalidNec
+          case None         => InvalidValue(in, s"$v is not a member of enum ${`enum`}").invalidNec
         }
       }
     }

--- a/json/src/main/scala/org/scalawag/bateman/json/decoding/JAny.scala
+++ b/json/src/main/scala/org/scalawag/bateman/json/decoding/JAny.scala
@@ -262,7 +262,6 @@ final case class JObject(
     val duplicateErrors = duplicateSets.flatMap { ff =>
       ff.tail.map(DuplicateField(_, ff.head))
     }
-    val thing = fieldsByName.view
     validIfEmpty(duplicateErrors, fieldsByName.view.mapValues(_.head).toMap)
   }
 

--- a/json/src/main/scala/org/scalawag/bateman/json/decoding/JAny.scala
+++ b/json/src/main/scala/org/scalawag/bateman/json/decoding/JAny.scala
@@ -18,6 +18,7 @@ import cats.data.NonEmptyChain
 import cats.syntax.validated._
 import org.scalawag.bateman.json.{encoding, validIfEmpty}
 import org.scalawag.bateman.json.decoding.parser.ParseResult
+import scala.collection.compat._
 
 /** Represents the type of JSON value as metadata. */
 
@@ -261,7 +262,8 @@ final case class JObject(
     val duplicateErrors = duplicateSets.flatMap { ff =>
       ff.tail.map(DuplicateField(_, ff.head))
     }
-    validIfEmpty(duplicateErrors, fieldsByName.mapValues(_.head).toMap)
+    val thing = fieldsByName.view
+    validIfEmpty(duplicateErrors, fieldsByName.view.mapValues(_.head).toMap)
   }
 
   /** Retrieves the value of the field with the specified name, if it exists.

--- a/json/src/main/scala/org/scalawag/bateman/json/package.scala
+++ b/json/src/main/scala/org/scalawag/bateman/json/package.scala
@@ -62,7 +62,7 @@ package object json {
 
   /** Returns [[None]] if its argument is empty and a [[Some]] containing the argument if it is not.  */
 
-  def noneIfEmpty[A <: Traversable[_]](a: A): Option[A] = if (a.isEmpty) None else Some(a)
+  def noneIfEmpty[A <: Iterable[_]](a: A): Option[A] = if (a.isEmpty) None else Some(a)
 
   /** Returns an invalid result containing all the errors unless errors is empty, in which case, it returns a valid
     * result containing its second argument. */

--- a/jsonGeneric/src/main/scala/org/scalawag/bateman/json/generic/DetectDiscriminatorCollisions.scala
+++ b/jsonGeneric/src/main/scala/org/scalawag/bateman/json/generic/DetectDiscriminatorCollisions.scala
@@ -23,7 +23,7 @@ object DetectDiscriminatorCollisions extends ErrorFormatters {
     val dups = discriminators.filter(_._2.size > 1)
     if (dups.nonEmpty) {
       val discs = dups.map {
-        case (d, cc) => s" - $label for classes ${formatAndList(cc.toIterator)} use the discriminator '$d'"
+        case (d, cc) => s" - $label for classes ${formatAndList(cc.iterator)} use the discriminator '$d'"
       }
       val msg = discs.mkString(s"There are multiple concrete $label with the same discriminator value:\n", "\n", "")
       throw ProgrammerError(msg)

--- a/jsonGeneric/src/main/scala/org/scalawag/bateman/json/generic/MacroBase.scala
+++ b/jsonGeneric/src/main/scala/org/scalawag/bateman/json/generic/MacroBase.scala
@@ -190,7 +190,7 @@ abstract class MacroBase(protected val c: Context) {
   protected implicit val typeEq: Eq[Type] = _ =:= _
   protected implicit val classSymbolEq: Eq[ClassSymbol] = Eq.fromUniversalEquals
 
-  protected implicit class TraversableOps[A](aa: Traversable[A]) {
+  protected implicit class TraversableOps[A](aa: Iterable[A]) {
     def groupByEq[K](f: A => K)(implicit K: Eq[K]): Map[K, List[A]] = {
       @tailrec
       def collapse(l: List[(K, List[A])], r: List[(K, List[A])]): List[(K, List[A])] =

--- a/jsonGeneric/src/main/scala/org/scalawag/bateman/json/generic/semiauto/Derivers.scala
+++ b/jsonGeneric/src/main/scala/org/scalawag/bateman/json/generic/semiauto/Derivers.scala
@@ -30,6 +30,7 @@ import org.scalawag.bateman.json.generic.encoding.{
   TraitEncoderFactory
 }
 import shapeless.Lazy
+import shapeless.Lazy.mkLazy
 
 object Derivers {
 
@@ -38,7 +39,7 @@ object Derivers {
         discriminatorField: OptionLike[String] = None,
         config: OptionLike[Config] = None
     )(implicit
-        encoderFactory: Lazy[TraitEncoderFactory[A]],
+        encoderFactory: Lazy[TraitEncoderFactory[A]] = mkLazy,
         defaultConfig: Config = Config.default
     ): TraitEncoder[A] =
       encoderFactory.value(discriminatorField, config.value.getOrElse(defaultConfig))
@@ -49,7 +50,7 @@ object Derivers {
         discriminatorValue: OptionLike[String] = None,
         config: OptionLike[Config] = None
     )(implicit
-        encoderFactory: Lazy[CaseClassEncoderFactory[A]],
+        encoderFactory: Lazy[CaseClassEncoderFactory[A]] = mkLazy,
         defaultConfig: Config = Config.default
     ): CaseClassEncoder[A] =
       encoderFactory.value(discriminatorValue.value, config.value.getOrElse(defaultConfig))
@@ -60,7 +61,7 @@ object Derivers {
         discriminatorField: OptionLike[String] = None,
         config: OptionLike[Config] = None
     )(implicit
-        decoderFactory: Lazy[TraitDecoderFactory[A, Context]],
+        decoderFactory: Lazy[TraitDecoderFactory[A, Context]] = mkLazy,
         defaultConfig: Config = Config.default
     ): TraitDecoder[A, Context] =
       decoderFactory.value(discriminatorField, config.value.getOrElse(defaultConfig))
@@ -71,7 +72,7 @@ object Derivers {
         discriminatorValue: OptionLike[String] = None,
         config: OptionLike[Config] = None
     )(implicit
-        decoderFactory: Lazy[CaseClassDecoderFactory[A, Context]],
+        decoderFactory: Lazy[CaseClassDecoderFactory[A, Context]] = mkLazy,
         defaultConfig: Config = Config.default
     ): CaseClassDecoder[A, Context] =
       decoderFactory.value(discriminatorValue.value, config.value.getOrElse(defaultConfig))
@@ -82,8 +83,8 @@ object Derivers {
         discriminatorField: OptionLike[String] = None,
         config: OptionLike[Config] = None
     )(implicit
-        encoderFactory: Lazy[TraitEncoderFactory[A]],
-        decoderFactory: Lazy[TraitDecoderFactory[A, Context]],
+        encoderFactory: Lazy[TraitEncoderFactory[A]] = mkLazy,
+        decoderFactory: Lazy[TraitDecoderFactory[A, Context]] = mkLazy,
         defaultConfig: Config = Config.default
     ): TraitCodec[A, Context] =
       TraitCodec(
@@ -97,8 +98,8 @@ object Derivers {
         discriminatorValue: OptionLike[String] = None,
         config: OptionLike[Config] = None
     )(implicit
-        encoderFactory: Lazy[CaseClassEncoderFactory[A]],
-        decoderFactory: Lazy[CaseClassDecoderFactory[A, Context]],
+        encoderFactory: Lazy[CaseClassEncoderFactory[A]] = mkLazy,
+        decoderFactory: Lazy[CaseClassDecoderFactory[A, Context]] = mkLazy,
         defaultConfig: Config = Config.default
     ): CaseClassCodec[A, Context] =
       CaseClassCodec(

--- a/jsonGeneric/src/test/scala/org/scalawag/bateman/json/generic/DerivedDecoderTest.scala
+++ b/jsonGeneric/src/test/scala/org/scalawag/bateman/json/generic/DerivedDecoderTest.scala
@@ -386,7 +386,7 @@ class DerivedDecoderTest extends AnyFunSpec with Matchers with ParserTestUtils {
 
       val da = JObjectDecoder[XNamedClass].decode(json)
       da shouldBe InvalidDiscriminator(
-        json("class").andThen(_.asString).getOrElse(fail),
+        json("class").andThen(_.asString).getOrElse(fail()),
         Iterable("y_named_class", "z-named-class")
       ).invalidNec
 

--- a/jsonGeneric/src/test/scala/org/scalawag/bateman/json/generic/decoding/JSourceTest.scala
+++ b/jsonGeneric/src/test/scala/org/scalawag/bateman/json/generic/decoding/JSourceTest.scala
@@ -134,7 +134,7 @@ class JSourceTest extends AnyFunSpec with Matchers with ParserTestUtils {
     xx.x.src shouldBe
       Some(
         JSource(
-          json.fields.getOrElse(fail)("x").value.asObject.getOrElse(fail),
+          json.fields.getOrElse(fail())("x").value.asObject.getOrElse(fail()),
           Map(
             "a" -> JPointer.Root / "a",
             "b" -> JPointer.Root / "b",

--- a/jsonGeneric/src/test/scala/org/scalawag/bateman/json/generic/decoding/OptionTest.scala
+++ b/jsonGeneric/src/test/scala/org/scalawag/bateman/json/generic/decoding/OptionTest.scala
@@ -43,7 +43,7 @@ class OptionTest extends AnyFunSpec with Matchers with ParserTestUtils with Data
   val jsonNumber = parseAs[JObject]("""{"a": 31}""")
   val jsonNull = parseAs[JObject]("""{"a": null}""")
 
-  val jsonNullA = jsonNull.fields.getOrElse(fail)("a").value.asNull.getOrElse(fail)
+  val jsonNullA = jsonNull.fields.getOrElse(fail())("a").value.asNull.getOrElse(fail())
 
   implicit val adec = semiauto.deriveDecoderForCaseClass[A, Any]()
   implicit val bdec = semiauto.deriveDecoderForCaseClass[B, Any]()

--- a/jsonGeneric/src/test/scala/org/scalawag/bateman/json/generic/encoding/OptionTest.scala
+++ b/jsonGeneric/src/test/scala/org/scalawag/bateman/json/generic/encoding/OptionTest.scala
@@ -42,7 +42,7 @@ class OptionTest extends AnyFunSpec with Matchers with ParserTestUtils with Data
 //  val jsonNumber = parseAs[JObject]("""{"a": 31}""")
 //  val jsonNull = parseAs[JObject]("""{"a": null}""")
 //
-//  val jsonNullA = jsonNull.fields.getOrElse(fail)("a").value.asNull.getOrElse(fail)
+//  val jsonNullA = jsonNull.fields.getOrElse(fail())("a").value.asNull.getOrElse(fail())
 
   implicit val aenc = semiauto.deriveEncoderForCaseClass[A]()
   implicit val benc = semiauto.deriveEncoderForCaseClass[B]()

--- a/jsonapi/src/main/scala/org/scalawag/bateman/jsonapi/encoding/IncludeSpec.scala
+++ b/jsonapi/src/main/scala/org/scalawag/bateman/jsonapi/encoding/IncludeSpec.scala
@@ -17,6 +17,7 @@ package org.scalawag.bateman.jsonapi.encoding
 import cats.data.NonEmptyChain
 import cats.syntax.validated._
 import org.scalawag.bateman.json.validIfEmpty
+import scala.collection.compat._
 
 /** Used to track the inclusion of related resources. This represents a node in the tree containing all the
   * include paths.
@@ -71,7 +72,7 @@ object IncludeSpec {
   def apply(spec: String, lengthLimit: Int = 1024, depthLimit: Int = 8): EncodeResult[IncludeSpec] = {
     def go(prefix: List[String], paths: Array[Array[String]]): IncludeSpec = {
       val children =
-        paths.groupBy(_.head).mapValues(_.map(_.tail)).toMap map {
+        paths.groupBy(_.head).view.mapValues(_.map(_.tail)).toMap map {
           case (h, pp) => h -> go(prefix :+ h, pp.filterNot(_.isEmpty))
         }
       Always(prefix.mkString("."), children)

--- a/jsonapiGeneric/src/main/scala/org/scalawag/bateman/jsonapi/generic/DetectResourceTypeCollisions.scala
+++ b/jsonapiGeneric/src/main/scala/org/scalawag/bateman/jsonapi/generic/DetectResourceTypeCollisions.scala
@@ -23,7 +23,7 @@ object DetectResourceTypeCollisions extends ErrorFormatters {
     val dups = discriminators.filter(_._2.size > 1)
     if (dups.nonEmpty) {
       val discs = dups.map {
-        case (d, cc) => s" - $label for classes ${formatAndList(cc.toIterator)} use the resource type '$d'"
+        case (d, cc) => s" - $label for classes ${formatAndList(cc.iterator)} use the resource type '$d'"
       }
       val msg = discs.mkString(s"There are multiple concrete $label with the same resource type:\n", "\n", "")
       throw ProgrammerError(msg)

--- a/jsonapiGeneric/src/main/scala/org/scalawag/bateman/jsonapi/generic/auto.scala
+++ b/jsonapiGeneric/src/main/scala/org/scalawag/bateman/jsonapi/generic/auto.scala
@@ -20,7 +20,6 @@ import org.scalawag.bateman.json.decoding.ContextualDecoder
 import org.scalawag.bateman.json.encoding.Encoder
 import org.scalawag.bateman.jsonapi.decoding.{ResourceDecoder, ResourceObjectOptionalId}
 import org.scalawag.bateman.jsonapi.generic.decoding.CaseClassResourceDecoderFactory
-import org.scalawag.bateman.jsonapi.{decoding, encoding}
 import shapeless.Lazy
 
 import scala.reflect.ClassTag

--- a/jsonapiGeneric/src/main/scala/org/scalawag/bateman/jsonapi/generic/decoding/HListResourceDecoder.scala
+++ b/jsonapiGeneric/src/main/scala/org/scalawag/bateman/jsonapi/generic/decoding/HListResourceDecoder.scala
@@ -77,22 +77,22 @@ object HListResourceDecoderFactoryFactory {
             //       the case class.
 
             val ids = input.in match {
-              case r: ResourceIdentifierLike => r.optionalId.toIterable.map(JPointer.Root / "id" -> _)
+              case r: ResourceIdentifierLike => r.optionalId.toList.map(JPointer.Root / "id" -> _)
               case _                         => Iterable.empty
             }
 
             val meta =
-              input.in.meta.toIterable.flatMap(_.mappings).map {
+              input.in.meta.toList.flatMap(_.mappings).map {
                 case (n, v) => JPointer.Root / "meta" / n.value -> v
               }
 
             val (attributes, relationships) = input.in match {
               case r: ResourceObjectLike =>
                 (
-                  r.attributes.toIterable.flatMap(_.mappings).map {
+                  r.attributes.toList.flatMap(_.mappings).map {
                     case (n, v) => JPointer.Root / "attributes" / n.value -> v
                   },
-                  r.relationships.toIterable.flatMap(_.mappings).map {
+                  r.relationships.toList.flatMap(_.mappings).map {
                     case (n, v) => JPointer.Root / "relationships" / n.value -> v.src.root
                   }
                 )

--- a/jsonapiGeneric/src/main/scala/org/scalawag/bateman/jsonapi/generic/encoding/PartialResource.scala
+++ b/jsonapiGeneric/src/main/scala/org/scalawag/bateman/jsonapi/generic/encoding/PartialResource.scala
@@ -59,7 +59,7 @@ final case class PartialResource(
   def addDeferredEncoding(deferredEncoding: DeferredEncoding): PartialResource =
     addDeferredEncodings(Iterable(deferredEncoding))
   def addDeferredEncoding(deferredEncoding: Option[DeferredEncoding]): PartialResource =
-    addDeferredEncodings(deferredEncoding.toIterable)
+    addDeferredEncodings(deferredEncoding.toList)
   def addDeferredEncodings(deferredEncodings: Iterable[DeferredEncoding]): PartialResource =
     this.copy(deferrals = this.deferrals ++ deferredEncodings)
 

--- a/jsonapiGeneric/src/test/scala/org/scalawag/bateman/jsonapi/generic/DerivedResourceObjectEncoderTest.scala
+++ b/jsonapiGeneric/src/test/scala/org/scalawag/bateman/jsonapi/generic/DerivedResourceObjectEncoderTest.scala
@@ -85,7 +85,7 @@ class DerivedResourceObjectEncoderTest extends AnyFunSpec with Matchers with Tes
       val enc =
         ResourceEncoder[Square, ResourceObject]
           .encodeResource(square, fieldsSpec = FieldsSpec(Map("square" -> Set("label", "parent"))))
-          .getOrElse(fail)
+          .getOrElse(fail())
       println(enc)
       val json = Encoder[ResourceObject, JObject].encode(enc.root)
       println(json.render(PrettySpaces2))
@@ -154,8 +154,8 @@ class DerivedResourceObjectEncoderTest extends AnyFunSpec with Matchers with Tes
     import DerivedResourceObjectEncoderTest._
 
     // Uses the encoder just to get the ResourceObject
-    def aro(a: A) = ResourceObjectEncoder[A].encodeResource(a).map(_.root).getOrElse(fail)
-    def bro(b: B) = ResourceObjectEncoder[B].encodeResource(b).map(_.root).getOrElse(fail)
+    def aro(a: A) = ResourceObjectEncoder[A].encodeResource(a).map(_.root).getOrElse(fail())
+    def bro(b: B) = ResourceObjectEncoder[B].encodeResource(b).map(_.root).getOrElse(fail())
 
     it("should not include the A") {
       val b = B("foo", A("bar", 17))

--- a/jsonapiGeneric/src/test/scala/org/scalawag/bateman/jsonapi/generic/decoding/DerivedFieldPointersTest.scala
+++ b/jsonapiGeneric/src/test/scala/org/scalawag/bateman/jsonapi/generic/decoding/DerivedFieldPointersTest.scala
@@ -151,14 +151,14 @@ class DerivedFieldPointersTest extends AnyFunSpec with Matchers with ParserTestU
 
     val xx = doc.dquery(_ ~> data ~> required ~> as[ResourceObject] ~> as[XX]).shouldSucceed
     xx.src.getFieldSource("x").shouldSucceed shouldBe doc.data.get.src.asObject
-      .getOrElse(fail)
+      .getOrElse(fail())
       .fields
-      .getOrElse(fail)("relationships")
+      .getOrElse(fail())("relationships")
       .value
       .asObject
-      .getOrElse(fail)
+      .getOrElse(fail())
       .fields
-      .getOrElse(fail)("x")
+      .getOrElse(fail())("x")
       .value
     xx.x.src.get.getFieldSource("c").shouldSucceed shouldBe JBoolean(
       false,

--- a/jsonapiGeneric/src/test/scala/org/scalawag/bateman/jsonapi/generic/decoding/HListResourceDecoderTest.scala
+++ b/jsonapiGeneric/src/test/scala/org/scalawag/bateman/jsonapi/generic/decoding/HListResourceDecoderTest.scala
@@ -82,8 +82,8 @@ class HListResourceDecoderTest extends AnyFunSpec with Matchers with ParserTestU
       """)
 
       val decoded = doc.cquery(doc)(_ ~> data ~> required ~> as[ResourceObject] ~> as[Square])
-      val un1 = doc.src.root.query(_ ~> "data" ~> "relationships" ~> "parent").getOrElse(fail)
-      val un2 = doc.src.root.query(_ ~> "data" ~> "meta" ~> "version").getOrElse(fail)
+      val un1 = doc.src.root.query(_ ~> "data" ~> "relationships" ~> "parent").getOrElse(fail())
+      val un2 = doc.src.root.query(_ ~> "data" ~> "meta" ~> "version").getOrElse(fail())
       decoded.leftMap(_.iterator.toSet) shouldBe Set(UnexpectedValue(un1), UnexpectedValue(un2)).invalid
     }
   }

--- a/parser/src/main/scala/org/scalawag/bateman/json/parser2/JsonParser.scala
+++ b/parser/src/main/scala/org/scalawag/bateman/json/parser2/JsonParser.scala
@@ -166,7 +166,7 @@ class JsonParser private (input: String, source: Option[String] = None) {
   private val lineForIndex: List[Int] =
     Source
       .fromString(input)
-      .getLines
+      .getLines()
       .map(_.length)
       .scanLeft(0)(_ + _ + 1)
       .toList

--- a/parser/src/test/scalajvm/org/scalawag/bateman/json/parser2/Performance.scala
+++ b/parser/src/test/scalajvm/org/scalawag/bateman/json/parser2/Performance.scala
@@ -91,7 +91,7 @@ class Performance extends AnyFunSpec with Matchers {
     }
     println(s"$ft x")
 
-    val src = input.toStream
+    val src = input.to(LazyList)
     val (bt, br) = time {
       for (_ <- 1 to iterations) yield parser.toJAny(src.to(LazyList))
     }

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -28,7 +28,7 @@ addSbtPlugin("ch.epfl.scala" % "sbt-version-policy" % "2.0.1")
 addSbtPlugin("com.typesafe" % "sbt-mima-plugin" % "1.1.1")
 addSbtPlugin("org.scalawag.sbt" % "sbt-git-flux" % "0.0.2")
 addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.11.0")
-addSbtPlugin("org.scala-js" % "sbt-scalajs" % "1.11.0")
+addSbtPlugin("org.scala-js" % "sbt-scalajs" % "1.13.0")
 
 addSbtPlugin("org.scalawag.sbt" %% "sbt-build-metadata" % "0.1.0-pre.2")
 


### PR DESCRIPTION
Update dependencies to match versions used in downstream services
Add `mkLazy` as a default value for `Lazy` parameters since it is no longer assumed
Resolve warnings such as
- enum being used without backticks (it will become a keyword in Scala 3)
- `toStream` instead of `to(LazyList)`
- `Traversable` instead of `Iterable`
- `toIterable` instead of an alternative
- methods invoked without parentheses